### PR TITLE
Add `resizeLetterbox` method

### DIFF
--- a/src/Grafika/EditorInterface.php
+++ b/src/Grafika/EditorInterface.php
@@ -151,7 +151,7 @@ interface EditorInterface {
      * @param ImageInterface $image Instance of Image.
      * @param int $newWidth Width in pixels.
      * @param int $newHeight Height in pixels.
-     * @param string $mode Resize mode. Possible values: "exact", "exactHeight", "exactWidth", "fill", "fit".
+     * @param string $mode Resize mode. Possible values: "exact", "exactHeight", "exactWidth", "fill", "fit", "letterbox".
      *
      * @return EditorInterface An instance of Editor.
      */
@@ -209,6 +209,18 @@ interface EditorInterface {
      * @return EditorInterface An instance of Editor.
      */
     public function resizeFit( &$image, $newWidth, $newHeight );
+
+    /**
+     * Resize an image to fit within the given width and height, then fill out the remaining space with a background color. The re-sized image + color fill will exactly match the given dimensions. Useful if you want to preserve the aspect ratio but also fill out an exact size.
+     *
+     * @param ImageInterface $image Instance of Image.
+     * @param int $newWidth Width in pixels.
+     * @param int $newHeight Width in pixels.
+     * @param Color $color The Color object containing the background color.
+     *
+     * @return EditorInterface An instance of Editor.
+     */
+    public function resizeLetterbox( &$image, $newWidth, $newHeight, $color);
 
     /**
      * Rotate an image counter-clockwise.

--- a/src/Grafika/Gd/Editor.php
+++ b/src/Grafika/Gd/Editor.php
@@ -666,6 +666,30 @@ final class Editor implements EditorInterface
     }
 
     /**
+     * Resize image to fit within the given width and height, then fill out the remaining space with a background color.
+     *
+     * @param Image $image
+     * @param int $newWidth Width in pixels.
+     * @param int $newHeight Height in pixels.
+     * @param Color $color The Color object containing the background color.
+     *
+     * @return Editor
+     */
+    public function resizeLetterbox(&$image, $newWidth, $newHeight, $color)
+    {
+
+        $canvas = Grafika::createBlankImage($newWidth, $newHeight);
+        $this->fill($canvas, $color);
+
+        $this->resizeFit($image, $newWidth, $newHeight);
+
+        $this->blend($canvas, $image, 'normal', 1, 'center');
+        $image = $canvas;
+
+        return $this;
+    }
+
+    /**
      * Rotate an image counter-clockwise.
      *
      * @param Image $image

--- a/src/Grafika/Gd/Editor.php
+++ b/src/Grafika/Gd/Editor.php
@@ -504,7 +504,7 @@ final class Editor implements EditorInterface
      * @param Image $image
      * @param int $newWidth Width in pixels.
      * @param int $newHeight Height in pixels.
-     * @param string $mode Resize mode. Possible values: "exact", "exactHeight", "exactWidth", "fill", "fit".
+     * @param string $mode Resize mode. Possible values: "exact", "exactHeight", "exactWidth", "fill", "fit", "letterbox".
      *
      * @return Editor
      * @throws \Exception
@@ -532,6 +532,9 @@ final class Editor implements EditorInterface
                 break;
             case 'fit':
                 $this->resizeFit($image, $newWidth, $newHeight);
+                break;
+            case 'letterbox':
+                $this->resizeLetterbox($image, $newWidth, $newHeight, new Color('#FFFFFF'));
                 break;
             default:
                 throw new \Exception(sprintf('Invalid resize mode "%s".', $mode));

--- a/src/Grafika/Imagick/Editor.php
+++ b/src/Grafika/Imagick/Editor.php
@@ -564,6 +564,30 @@ final class Editor implements EditorInterface
     }
 
     /**
+     * Resize image to fit within the given width and height, then fill out the remaining space with a background color.
+     *
+     * @param Image $image
+     * @param int $newWidth Width in pixels.
+     * @param int $newHeight Height in pixels.
+     * @param Color $color The Color object containing the background color.
+     *
+     * @return Editor
+     */
+    public function resizeLetterbox(&$image, $newWidth, $newHeight, $color)
+    {
+
+        $canvas = Grafika::createBlankImage($newWidth, $newHeight);
+        $this->fill($canvas, $color);
+
+        $this->resizeFit($image, $newWidth, $newHeight);
+
+        $this->blend($canvas, $image, 'normal', 1, 'center');
+        $image = $canvas;
+
+        return $this;
+    }
+
+    /**
      * Rotate an image counter-clockwise.
      *
      * @param Image $image

--- a/src/Grafika/Imagick/Editor.php
+++ b/src/Grafika/Imagick/Editor.php
@@ -402,7 +402,7 @@ final class Editor implements EditorInterface
      * @param Image $image
      * @param int $newWidth Width in pixels.
      * @param int $newHeight Height in pixels.
-     * @param string $mode Resize mode. Possible values: "exact", "exactHeight", "exactWidth", "fill", "fit".
+     * @param string $mode Resize mode. Possible values: "exact", "exactHeight", "exactWidth", "fill", "fit", "letterbox".
      *
      * @return Editor
      * @throws \Exception
@@ -430,6 +430,9 @@ final class Editor implements EditorInterface
                 break;
             case 'fit':
                 $this->resizeFit($image, $newWidth, $newHeight);
+                break;
+            case 'letterbox':
+                $this->resizeLetterbox($image, $newWidth, $newHeight, new Color('#FFFFFF'));
                 break;
             default:
                 throw new \Exception(sprintf('Invalid resize mode "%s".', $mode));


### PR DESCRIPTION
Combines the behavior of `resizeFill` with `resizeFit` (aspect ratio is preserved, but the extra space is filled in with a solid color so the resulting image is the exact desired dimensions).

I did not add anything to the docs yet because I'm not sure how that is built/structured (looks like a compilation step of some kind is involved?). Also, I am not an expert with GD or ImageMagick -- I only composed some existing functions to make this work, so it's possible I am doing something inefficient or bad with memory or maybe it messes up animated gifs?

btw, thanks for this great library -- it's exactly what I was looking for (I especially like the emphasis on resizing, because that's 99% of what I do with image manipulation)!