### PR TITLE
Bug fix: strict type check in Editor blend functions

### DIFF
--- a/src/Grafika/EditorInterface.php
+++ b/src/Grafika/EditorInterface.php
@@ -30,7 +30,7 @@ interface EditorInterface {
      *
      * @return EditorInterface An instance of Editor.
      */
-    public function blend(&$image1, $image2, $type='normal', $opacity = 1.0, $position = 'top-left', $offsetX = 0, $offsetY = 0 );
+    public function blend(ImageInterface &$image1, ImageInterface $image2, $type = 'normal', float $opacity = 1.0, string $position = 'top-left', int $offsetX = 0, int $offsetY = 0);
 
     /**
      * Compare two images and returns a hamming distance. A value of 0 indicates a likely similar picture. A value between 1 and 10 is potentially a variation. A value greater than 10 is likely a different image.

--- a/src/Grafika/Gd/Editor.php
+++ b/src/Grafika/Gd/Editor.php
@@ -54,7 +54,7 @@ final class Editor implements EditorInterface
      * @return Editor
      * @throws \Exception When added image is outside of canvas or invalid blend type
      */
-    public function blend(&$image1, $image2, $type='normal', $opacity = 1.0, $position = 'top-left', $offsetX = 0, $offsetY = 0 ){
+    public function blend(ImageInterface &$image1, ImageInterface $image2, $type='normal', float $opacity = 1.0, string $position = 'top-left', int $offsetX = 0, int $offsetY = 0) {
 
         // Turn into position object
         $position = new Position($position, $offsetX, $offsetY);
@@ -113,7 +113,7 @@ final class Editor implements EditorInterface
 
         $type = strtolower( $type );
         if($type==='normal') {
-            if ( $opacity !== 1 ) {
+            if ( $opacity !== 1.0 ) {
                 $this->opacity($image2, $opacity);
             }
             imagecopy( $canvas, $gd2, $loopStartX + $offsetX, $loopStartY + $offsetY, 0, 0, $image2->getWidth(), $image2->getHeight());

--- a/src/Grafika/Imagick/Editor.php
+++ b/src/Grafika/Imagick/Editor.php
@@ -53,8 +53,8 @@ final class Editor implements EditorInterface
      * @return Editor
      * @throws \Exception When added image is outside of canvas or invalid blend type
      */
-    public function blend(&$image1, $image2, $type='normal', $opacity = 1.0, $position = 'top-left', $offsetX = 0, $offsetY = 0 ){
-
+    public function blend(ImageInterface &$image1, ImageInterface $image2, $type = 'normal', float $opacity = 1.0, string $position = 'top-left', int $offsetX = 0, int $offsetY = 0)
+    {
         // Turn into position object
         $position = new Position($position, $offsetX, $offsetY);
 
@@ -86,7 +86,7 @@ final class Editor implements EditorInterface
             $loopStartY += $diff;
         }
 
-        if ( $opacity !== 1 ) {
+        if ( $opacity !== 1.0 ) {
             $this->opacity($image2, $opacity);
         }
 


### PR DESCRIPTION
Small PR for you. 
`$opacity !== 1` passes with default values because float `1.0` (default value) is not equal to integer `1`.

Added type hints to ensure user values are correct.
Possibly related: #18 